### PR TITLE
#86 Support render from .osm

### DIFF
--- a/style.css
+++ b/style.css
@@ -12,6 +12,7 @@
 
 body {
   margin: 0;
+  background-color: #222;
 }
 
 /* Add a background color to the button if it is clicked on (add the .active class with JS), and when you move the mouse over it (hover) */


### PR DESCRIPTION
Implements #86

Workflow:

https://github.com/user-attachments/assets/2910a047-9f32-4d1d-b8e6-6f953259c36d

More advanced users can run `python3 -m http.server 1337` specifying http://localhost:1337/3d.osm and simply reloading the tab. I'll document this.


Support multiple ways in holes. `&type=relation&id=13285666&info`:

<table>

<th>

Before

<th>

After

<tr>

<td>

<img width="1107" 
 src="https://github.com/user-attachments/assets/60646fc4-7b4d-4370-9fbd-5c1e22d172bb" />


<td>

<img width="931" 
 src="https://github.com/user-attachments/assets/a78dea7a-34c0-463a-bd03-1d3307ca7485" />


</tr>

</table>