### PR TITLE
test for infinite loop in combineWays() / rewrite combineWays

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,6 +24,6 @@ jobs:
     - name: Lint
       run: yarn run eslint .
     - name: Test
-      run: CI=true NODE_OPTIONS="$NODE_OPTIONS --experimental-vm-modules" npm test
+      run: CI=true NODE_OPTIONS="$NODE_OPTIONS --experimental-vm-modules" timeout 20s npm test
     - name: Coveralls
       uses: coverallsapp/github-action@v2

--- a/test/combine_ways.test.js
+++ b/test/combine_ways.test.js
@@ -59,6 +59,12 @@ describe('Combine Ways', () => {
         '<way id="4"><nd ref="2"/><nd ref="3"/></way>',
       ], 1, 5, 'Test combining 4 ways',
     ],
+    [
+      [
+        '<way id="1"><nd ref="1"/><nd ref="2"/></way>',
+        '<way id="2"><nd ref="3"/><nd ref="2"/></way>',
+      ], 0, 0, 'Test combining 2 open ways',
+    ],
   ])('${description}', (ways, length, nodes, description) => {
     let parser = new window.DOMParser();
     const xml = [];
@@ -67,8 +73,10 @@ describe('Combine Ways', () => {
     }
     let result = BuildingShapeUtils.combineWays(xml);
     expect(result.length).toBe(length);
-    expect(BuildingShapeUtils.isClosed(result[0]));
-    expect(BuildingShapeUtils.isSelfIntersecting(result[0])).toBe(false);
-    expect(result[0].getElementsByTagName('nd').length).toBe(nodes);
+    if (length) {
+      expect(BuildingShapeUtils.isClosed(result[0]));
+      expect(BuildingShapeUtils.isSelfIntersecting(result[0])).toBe(false);
+      expect(result[0].getElementsByTagName('nd').length).toBe(nodes);
+    }
   });
 });


### PR DESCRIPTION
1. I set a global timeout for tests. jest's built-in `testTimeout` doesn't work in this case.
2. Added a test where the current implementation of `combineWays()` gets stuck.

Second commit: new combineWays() from #84