### PR TITLE
Skip incompleted ways, skip non-way members, prevent global modification of way object

### DIFF
--- a/src/building.js
+++ b/src/building.js
@@ -198,7 +198,11 @@ class Building {
       for (let i = 0; i < parts.length; i++) {
         if (parts[i].querySelector('[k="building:part"]')) {
           const id = parts[i].getAttribute('id');
-          this.parts.push(new MultiBuildingPart(id, this.fullXmlData, this.nodelist, this.outerElement.options));
+          try {
+            this.parts.push(new MultiBuildingPart(id, this.fullXmlData, this.nodelist, this.outerElement.options));
+          } catch (e) {
+            window.printError(e);
+          }
         }
       }
     }

--- a/src/multibuildingpart.js
+++ b/src/multibuildingpart.js
@@ -14,8 +14,8 @@ class MultiBuildingPart extends BuildingPart {
    */
   buildShape() {
     this.type = 'multipolygon';
-    const innerMembers = this.way.querySelectorAll('member[role="inner"]');
-    const outerMembers = this.way.querySelectorAll('member[role="outer"]');
+    const innerMembers = this.way.querySelectorAll('member[role="inner"][type="way"]');
+    const outerMembers = this.way.querySelectorAll('member[role="outer"][type="way"]');
     const innerShapes = [];
     var shapes = [];
     for (let i = 0; i < innerMembers.length; i++) {
@@ -25,7 +25,10 @@ class MultiBuildingPart extends BuildingPart {
     const ways = [];
     for (let j = 0; j < outerMembers.length; j++) {
       const way = this.fullXmlData.getElementById(outerMembers[j].getAttribute('ref'));
-      ways.push(way);
+      if (way === null) {
+        throw `Incompleted way ${outerMembers[j].getAttribute('ref')}`;
+      }
+      ways.push(way.cloneNode(true));
     }
     const closedWays = BuildingShapeUtils.combineWays(ways);
     for (let k = 0; k < closedWays.length; k++) {

--- a/test/building.test.js
+++ b/test/building.test.js
@@ -97,6 +97,50 @@ test('Visible Outer Building', () => {
   expect(mesh[1].visible).toBe(true);
 });
 
+
+test('Test with neighboring incomplete building:part relation', () => {
+  const data = `<?xml version="1.0" encoding="UTF-8"?>
+<osm>
+ <node id="1" lat="59.9297360" lon="30.4883115"/>
+ <node id="2" lat="59.9293517" lon="30.4883115"/>
+ <node id="3" lat="59.9293516" lon="30.4892180"/>
+ <node id="4" lat="59.9297360" lon="30.4892179"/>
+ <node id="5" lat="59.9279610" lon="30.4840202"/>
+ <node id="6" lat="59.9295379" lon="30.4879181"/>
+ <node id="7" lat="59.9283455" lon="30.4831137"/>
+ <way id="222">
+  <nd ref="3"/>
+  <nd ref="4"/>
+  <nd ref="1"/>
+ </way>
+ <way id="333">
+  <nd ref="1"/>
+  <nd ref="2"/>
+  <nd ref="3"/>
+ </way>
+ <way id="444">
+  <nd ref="5"/>
+  <nd ref="6"/>
+  <nd ref="7"/>
+ </way>
+ <relation id="42">
+  <member type="way" ref="222" role="outer"/>
+  <member type="way" ref="333" role="outer"/>
+  <tag k="building" v="apartments"/>
+  <tag k="type" v="multipolygon"/>
+ </relation>
+ <relation id="40">
+  <member type="way" ref="444" role="outer"/>
+  <member type="way" ref="1000" role="outer"/>
+  <tag k="building:part" v="yes"/>
+  <tag k="type" v="multipolygon"/>
+ </relation>
+</osm>
+`;
+  expect(new Building('42', data).id).toBe('42');
+});
+
+
 window.printError = printError;
 
 var errors = [];

--- a/test/multipolygon.test.js
+++ b/test/multipolygon.test.js
@@ -16,7 +16,7 @@ const data = `
   <node id="6" lat="4.001" lon="4.001"/>
   <node id="7" lat="4.001" lon="4"/>
   <relation id="4">
-    <member ref="1" role="outer"/>
+    <member ref="1" role="outer" type="way"/>
     <tag k="type" v="multipolygon"/>
     <tag k="building" v="yes"/>
     <tag k="roof:shape" v="skillion"/>

--- a/test/split_way_multipolygon.test.js
+++ b/test/split_way_multipolygon.test.js
@@ -19,9 +19,9 @@ const data = `
   <node id="9" lat="4.00025" lon="4.00075"/>
   <node id="10" lat="4.00075" lon="4.0005"/>
   <relation id="5">
-    <member ref="1" role="outer"/>
-    <member ref="3" role="outer"/>
-    <member ref="2" role="inner"/>
+    <member ref="1" role="outer" type="way"/>
+    <member ref="3" role="outer" type="way"/>
+    <member ref="2" role="inner" type="way"/>
     <tag k="type" v="multipolygon"/>
     <tag k="building" v="yes"/>
     <tag k="roof:shape" v="skillion"/>

--- a/test/split_way_multipolygon_reverse.test.js
+++ b/test/split_way_multipolygon_reverse.test.js
@@ -19,9 +19,9 @@ const data = `
   <node id="9" lat="4.00025" lon="4.00075"/>
   <node id="10" lat="4.00075" lon="4.0005"/>
   <relation id="5">
-    <member ref="1" role="outer"/>
-    <member ref="3" role="outer"/>
-    <member ref="2" role="inner"/>
+    <member ref="1" role="outer" type="way"/>
+    <member ref="3" role="outer" type="way"/>
+    <member ref="2" role="inner" type="way"/>
     <tag k="type" v="multipolygon"/>
     <tag k="building" v="yes"/>
     <tag k="roof:shape" v="skillion"/>


### PR DESCRIPTION
1. You convinced me that there is no need to download incompleted parts :) I made it so that they are skipped.

2. It is also important to check that the members of the relation are ways, otherwise it will lead to a crash.

3. `ways.push(way);` replaced by`ways.push(way.cloneNode(true));`, because in complex buildings, the way can be reused for different parts of the building and cannot be modified

It doesn't fix the Chrysler Building, but it does fix https://deevroman.github.io/OSMBuilding/?type=relation&id=5428216

With download:
<img width="50%"  src="https://github.com/user-attachments/assets/5a514854-f943-4769-8c54-801778e4296e" />

With this PR:
<img width="50%" alt="" src="https://github.com/user-attachments/assets/1d5ee2ec-6ced-494d-91bd-4856c3ea6a1f" />
