### PR TITLE
Tests for API

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,7 +22,7 @@
         }
       }
     </script>
-    <script src="./src/apis.js"></script>
+    <script type="module" src="./src/apis.js"></script>
     <script type="module" src="./src/index.js"></script>
     <div id="errorBox" style="position:absolute; top:10px; display:block; z-index:100; background-color: #ffffff; white-space:pre-line"></div>
 </body>

--- a/src/apis.js
+++ b/src/apis.js
@@ -1,5 +1,5 @@
 const osmApiUrl = new URLSearchParams(location.search).get('osmApiUrl') || 'https://api.openstreetmap.org/api/0.6';
-const apis = {
+export const apis = {
   bounding: {
     api: osmApiUrl + '/map?bbox=',
     url: (left, bottom, right, top) => {

--- a/src/building.js
+++ b/src/building.js
@@ -1,3 +1,4 @@
+import {apis} from './apis.js';
 import {BuildingShapeUtils} from './extras/BuildingShapeUtils.js';
 import {BuildingPart} from './buildingpart.js';
 import {MultiBuildingPart} from './multibuildingpart.js';

--- a/src/building.js
+++ b/src/building.js
@@ -192,24 +192,39 @@ class Building {
   static async getWayData(id) {
     let restPath = apis.getWay.url(id);
     let response = await fetch(restPath);
-    let text = await response.text();
-    return text;
+    if (response.status === 404) {
+      throw `The way ${id} was not found on the server.\nURL: ${restPath}`;
+    } else if (response.status === 410) {
+      throw `The way ${id} was deleted.\nURL: ${restPath}`;
+    } else if (response.status !== 200) {
+      throw `HTTP ${response.status}.\nURL: ${restPath}`;
+    }
+    return await response.text();
   }
 
   static async getRelationData(id) {
     let restPath = apis.getRelation.url(id);
     let response = await fetch(restPath);
-    let text = await response.text();
-    return text;
+    if (response.status === 404) {
+      throw `The relation ${id} was not found on the server.\nURL: ${restPath}`;
+    } else if (response.status === 410) {
+      throw `The relation ${id} was deleted.\nURL: ${restPath}`;
+    } else if (response.status !== 200) {
+      throw `HTTP ${response.status}.\nURL: ${restPath}`;
+    }
+    return await response.text();
   }
 
   /**
-   * Fetch way data from OSM
+   * Fetch map data data from OSM
    */
   static async getInnerData(left, bottom, right, top) {
-    let response = await fetch(apis.bounding.url(left, bottom, right, top));
-    let res = await response.text();
-    return res;
+    let url = apis.bounding.url(left, bottom, right, top);
+    let response = await fetch(url);
+    if (response.status !== 200) {
+      throw `HTTP ${response.status}.\nURL: ${url}`;
+    }
+    return await response.text();
   }
 
   /**

--- a/src/index.js
+++ b/src/index.js
@@ -79,6 +79,9 @@ function init() {
         createFolders(folder, part.options);
       }
     }
+  }).catch(err => {
+    window.printError(err);
+    alert(err);
   });
   camera = new PerspectiveCamera(
     50,


### PR DESCRIPTION
I did `src/apis.js` a module so that it can be used in tests. I also added tests to check the HTTP code for each status.

These are weak tests, but now we know that jest-fetch-mock works. What is the essence of the example:

`fetch.mockResponses(res1, res2, res3, ....);` accepts vararg, with how to mock fetch (in other words, you can mock multiple fetch calls). `resN` is an array, the first element is the body, and the second is the request properties, such as status.

Also in index.js an alert is now displayed if an exception occurs