### PR TITLE
Fix crash when processing type=building with outline being a multipolygon

### DIFF
--- a/test/building.test.js
+++ b/test/building.test.js
@@ -174,6 +174,142 @@ test('Test with neighboring incomplete building:part relation', () => {
   expect(new Building('42', data).id).toBe('42');
 });
 
+const typeBuildingWithMultipolygonOutline = `<?xml version='1.0' encoding='UTF-8'?>
+<osm version="0.6">
+  <node id="1" lat="59.938127" lon="30.4980057"/>
+  <node id="2" lat="59.9380365" lon="30.4992843"/>
+  <node id="3" lat="59.9384134" lon="30.4993839"/>
+  <node id="4" lat="59.9385087" lon="30.4981066"/>
+  <node id="5" lat="59.9381203" lon="30.4989364"/>
+  <node id="6" lat="59.93838" lon="30.499005"/>
+  <node id="7" lat="59.9384221" lon="30.498439"/>
+  <node id="8" lat="59.9381551" lon="30.4983684"/>
+  <way id="20">
+    <nd ref="4"/>
+    <nd ref="3"/>
+    <nd ref="2"/>
+    <nd ref="1"/>
+  </way>
+  <way id="21">
+    <nd ref="1"/>
+    <nd ref="4"/>
+  </way>
+  <way id="22">
+    <nd ref="6"/>
+    <nd ref="7"/>
+  </way>
+  <way id="23">
+    <nd ref="5"/>
+    <nd ref="6"/>
+  </way>
+  <way id="24">
+    <nd ref="8"/>
+    <nd ref="5"/>
+  </way>
+  <way id="25">
+    <nd ref="7"/>
+    <nd ref="8"/>
+  </way>
+  <relation id="40">
+    <member type="way" ref="20" role="outer"/>
+    <member type="way" ref="21" role="outer"/>
+    <member type="way" ref="22" role="inner"/>
+    <member type="way" ref="23" role="inner"/>
+    <member type="way" ref="24" role="inner"/>
+    <member type="way" ref="25" role="inner"/>
+    <tag k="building" v="school"/>
+    <tag k="building:levels" v="3"/>
+    <tag k="roof:shape" v="flat"/>
+    <tag k="type" v="multipolygon"/>
+  </relation>
+  <relation id="42">
+    <member type="relation" ref="40" role="outline"/>
+    <tag k="type" v="building"/>
+  </relation>
+</osm>
+`;
+const typeBuildingRelationFullResponse = `<?xml version='1.0' encoding='UTF-8'?>
+<osm version="0.6">
+  <relation id="40">
+    <member type="way" ref="20" role="outer"/>
+    <member type="way" ref="21" role="outer"/>
+    <member type="way" ref="22" role="inner"/>
+    <member type="way" ref="23" role="inner"/>
+    <member type="way" ref="24" role="inner"/>
+    <member type="way" ref="25" role="inner"/>
+    <tag k="building" v="school"/>
+    <tag k="building:levels" v="3"/>
+    <tag k="roof:shape" v="flat"/>
+    <tag k="type" v="multipolygon"/>
+  </relation>
+  <relation id="42">
+    <member type="relation" ref="40" role="outline"/>
+    <tag k="type" v="building"/>
+  </relation>
+</osm>
+`;
+const outlineRelationFullResponse = `<?xml version='1.0' encoding='UTF-8'?>
+<osm version="0.6">
+  <node id="1" lat="59.938127" lon="30.4980057"/>
+  <node id="2" lat="59.9380365" lon="30.4992843"/>
+  <node id="3" lat="59.9384134" lon="30.4993839"/>
+  <node id="4" lat="59.9385087" lon="30.4981066"/>
+  <node id="5" lat="59.9381203" lon="30.4989364"/>
+  <node id="6" lat="59.93838" lon="30.499005"/>
+  <node id="7" lat="59.9384221" lon="30.498439"/>
+  <node id="8" lat="59.9381551" lon="30.4983684"/>
+  <way id="20">
+    <nd ref="4"/>
+    <nd ref="3"/>
+    <nd ref="2"/>
+    <nd ref="1"/>
+  </way>
+  <way id="21">
+    <nd ref="1"/>
+    <nd ref="4"/>
+  </way>
+  <way id="22">
+    <nd ref="6"/>
+    <nd ref="7"/>
+  </way>
+  <way id="23">
+    <nd ref="5"/>
+    <nd ref="6"/>
+  </way>
+  <way id="24">
+    <nd ref="8"/>
+    <nd ref="5"/>
+  </way>
+  <way id="25">
+    <nd ref="7"/>
+    <nd ref="8"/>
+  </way>
+  <relation id="40">
+    <member type="way" ref="20" role="outer"/>
+    <member type="way" ref="21" role="outer"/>
+    <member type="way" ref="22" role="inner"/>
+    <member type="way" ref="23" role="inner"/>
+    <member type="way" ref="24" role="inner"/>
+    <member type="way" ref="25" role="inner"/>
+    <tag k="building" v="school"/>
+    <tag k="building:levels" v="3"/>
+    <tag k="roof:shape" v="flat"/>
+    <tag k="type" v="multipolygon"/>
+  </relation>
+</osm>
+`;
+
+test('Test downloading type=building with multipolygon outline and multiple inner ways', async() => {
+  fetch.mockResponses(
+    [typeBuildingRelationFullResponse],    // /relation/42/full
+    [outlineRelationFullResponse],         // /relation/40/full
+    [typeBuildingWithMultipolygonOutline], // /map call
+  );
+  const innerData = await Building.downloadDataAroundBuilding('relation', '42');
+  const building = new Building('42', innerData);
+  expect(building.id).toBe('42');
+  expect(building.outerElement.shape.holes.length).toBe(1);
+});
 
 window.printError = printError;
 


### PR DESCRIPTION
fix #88
https://beakerboy.github.io/OSMBuilding/?type=relation&id=19046126 It doesn't work for two reasons

1. In this relation, all members are relations. The API call /full does not load the child relations recursively, so we do not get nodes. `getExtends()` then returns a bbox spanning the entire world, and `/map` fails.

2. But that's not all. The current implementation of `buildShape()` doesn't take into account that inner can be open ways individually, but together form a ring. This is only taken into account for outer ways, so I moved this logic into the `makeRings()` function, and call it to get both `outerShapes` and `innerShapes`

This problem looks like this:

<table>

<th>

Before

<th>

After

<tr>

<td>

<img width="1107" 
 src="https://github.com/user-attachments/assets/60646fc4-7b4d-4370-9fbd-5c1e22d172bb" />


<td>

<img width="931" 
 src="https://github.com/user-attachments/assets/a78dea7a-34c0-463a-bd03-1d3307ca7485" />


</tr>

</table>


And I wrote a test that tests the downloading of child relations and checks that the correct number of holes are created in the building.

Visually the test looks like this:
<img width="564" src="https://github.com/user-attachments/assets/b3e7cd84-1fbb-438a-bed2-51025b1139a6" />

